### PR TITLE
Add support for encoding to DelimitedDataReader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
-+## [4.0.0] — 2016-12-21
+### Added
+
+- Add support for specifying encoding of input data.
+
+## [4.0.0] — 2016-12-21
 
 ### Added
 

--- a/src/DelimitedDataParser/DelimitedDataReader.cs
+++ b/src/DelimitedDataParser/DelimitedDataReader.cs
@@ -162,7 +162,7 @@ namespace DelimitedDataParser
 
             if (buffer == null)
             {
-                return _encoding.GetMaxByteCount(chars.Length);
+                return charsAsBytes.Length;
             }
 
             if (bufferOffset < 0 || bufferOffset >= buffer.Length)
@@ -175,12 +175,12 @@ namespace DelimitedDataParser
                 throw new ArgumentOutOfRangeException(nameof(ordinal));
             }
 
-            if (dataOffset < 0 || dataOffset >= chars.Length)
+            if (dataOffset < 0 || dataOffset >= charsAsBytes.Length)
             {
                 throw new ArgumentOutOfRangeException(nameof(dataOffset));
             }
 
-            // This cast should be safe as chars.length is an int and we know that dataOffset fits inside 0 - chars.length from the above. Is there any better way to handle this?
+            // This cast should be safe as dataOffset is between 0 and charsAsBytes.length from the above.
             var dataOffsetInt = (int)dataOffset;
             var sourceLengthInBytes = charsAsBytes.Length - dataOffsetInt;
             var destLengthInBytes = buffer.Length - bufferOffset;

--- a/src/DelimitedDataParser/Parser.cs
+++ b/src/DelimitedDataParser/Parser.cs
@@ -120,6 +120,9 @@ namespace DelimitedDataParser
         /// <param name="textReader">
         /// The <see cref="TextReader"/> containing the delimited data to read.
         /// </param>
+        /// <param name="encoding">
+        /// The <see cref="Encoding"/> used to read data. The <see cref="Encoding.Default"/> value is used if a null value is supplied.
+        /// </param>
         /// <returns>A <see cref="DbDataReader"/> that will read rows of data.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="textReader"/> is null.</exception>
         public virtual DbDataReader ParseReader(TextReader textReader, Encoding encoding = null)
@@ -138,6 +141,28 @@ namespace DelimitedDataParser
                 textReader,
                 encoding,
                 _fieldSeparator, 
+                _useFirstRowAsColumnHeaders);
+        }
+
+        /// <summary>
+        /// Create a data reader that will read from the <paramref name="streamReader"/>.
+        /// </summary>
+        /// <param name="streamReader">
+        /// The <see cref="StreamReader"/> containing the delimited data to read. The stream encoding is used to read this data.
+        /// </param>
+        /// <returns>A <see cref="DbDataReader"/> that will read rows of data.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="streamReader"/> is null.</exception>
+        public virtual DbDataReader ParseReader(StreamReader streamReader)
+        {
+            if (streamReader == null)
+            {
+                throw new ArgumentNullException(nameof(streamReader));
+            }
+
+            return new DelimitedDataReader(
+                streamReader,
+                streamReader.CurrentEncoding,
+                _fieldSeparator,
                 _useFirstRowAsColumnHeaders);
         }
 

--- a/src/DelimitedDataParser/Parser.cs
+++ b/src/DelimitedDataParser/Parser.cs
@@ -84,11 +84,16 @@ namespace DelimitedDataParser
         /// <returns>The <see cref="DataTable"/> containing the parsed data.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="textReader"/> is null.</exception>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
-        public virtual DataTable Parse(TextReader textReader)
+        public virtual DataTable Parse(TextReader textReader, Encoding encoding = null)
         {
             if (textReader == null)
             {
                 throw new ArgumentNullException(nameof(textReader));
+            }
+
+            if (encoding == null)
+            {
+                encoding = Encoding.Default;
             }
 
             var output = new DataTable
@@ -96,7 +101,7 @@ namespace DelimitedDataParser
                 Locale = CultureInfo.CurrentCulture
             };
 
-            var reader = ParseReader(textReader);
+            var reader = ParseReader(textReader, encoding);
             output.Load(reader);
 
             if (_columnNamesAsText != null && _columnNamesAsText.Any())
@@ -117,14 +122,23 @@ namespace DelimitedDataParser
         /// </param>
         /// <returns>A <see cref="DbDataReader"/> that will read rows of data.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="textReader"/> is null.</exception>
-        public virtual DbDataReader ParseReader(TextReader textReader)
+        public virtual DbDataReader ParseReader(TextReader textReader, Encoding encoding = null)
         {
             if (textReader == null)
             {
                 throw new ArgumentNullException(nameof(textReader));
             }
 
-            return new DelimitedDataReader(textReader, _fieldSeparator, _useFirstRowAsColumnHeaders);
+            if (encoding == null)
+            {
+                encoding = Encoding.Default;
+            }
+
+            return new DelimitedDataReader(
+                textReader,
+                encoding,
+                _fieldSeparator, 
+                _useFirstRowAsColumnHeaders);
         }
 
         /// <summary>

--- a/src/DelimitedDataParser/Parser.cs
+++ b/src/DelimitedDataParser/Parser.cs
@@ -78,13 +78,33 @@ namespace DelimitedDataParser
         /// <summary>
         /// Parse the input <see cref="TextReader"/> as a <see cref="DataTable"/>.
         /// </summary>
+        /// <remarks>
+        /// This method assumes an encoding of <see cref="Encoding.Default"/>.
+        /// </remarks>
         /// <param name="textReader">
         /// The <see cref="TextReader"/> containing the delimited data to read.
         /// </param>
         /// <returns>The <see cref="DataTable"/> containing the parsed data.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="textReader"/> is null.</exception>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
-        public virtual DataTable Parse(TextReader textReader, Encoding encoding = null)
+        public virtual DataTable Parse(TextReader textReader)
+        {
+            return Parse(textReader, Encoding.Default);
+        }
+
+        /// <summary>
+        /// Parse the input <see cref="TextReader"/> as a <see cref="DataTable"/>.
+        /// </summary>
+        /// <param name="textReader">
+        /// The <see cref="TextReader"/> containing the delimited data to read.
+        /// </param>
+        /// <param name="encoding">
+        /// The character encoding to use.
+        /// </param>
+        /// <returns>The <see cref="DataTable"/> containing the parsed data.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="textReader"/> or <paramref name="encoding"/> is null.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
+        public virtual DataTable Parse(TextReader textReader, Encoding encoding)
         {
             if (textReader == null)
             {
@@ -93,7 +113,7 @@ namespace DelimitedDataParser
 
             if (encoding == null)
             {
-                encoding = Encoding.Default;
+                throw new ArgumentNullException(nameof(encoding));
             }
 
             var output = new DataTable
@@ -117,15 +137,31 @@ namespace DelimitedDataParser
         /// <summary>
         /// Create a data reader that will read from the <paramref name="textReader"/>.
         /// </summary>
+        /// <remarks>
+        /// This method assumes an encoding of <see cref="Encoding.Default"/>.
+        /// </remarks>
+        /// <param name="textReader">
+        /// The <see cref="TextReader"/> containing the delimited data to read.
+        /// </param>
+        /// <returns>A <see cref="DbDataReader"/> that will read rows of data.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="textReader"/> is null.</exception>
+        public virtual DbDataReader ParseReader(TextReader textReader)
+        {
+            return ParseReader(textReader, Encoding.Default);
+        }
+
+        /// <summary>
+        /// Create a data reader that will read from the <paramref name="textReader"/>.
+        /// </summary>
         /// <param name="textReader">
         /// The <see cref="TextReader"/> containing the delimited data to read.
         /// </param>
         /// <param name="encoding">
-        /// The <see cref="Encoding"/> used to read data. The <see cref="Encoding.Default"/> value is used if a null value is supplied.
+        /// The character encoding to use.
         /// </param>
         /// <returns>A <see cref="DbDataReader"/> that will read rows of data.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="textReader"/> is null.</exception>
-        public virtual DbDataReader ParseReader(TextReader textReader, Encoding encoding = null)
+        /// <exception cref="ArgumentNullException"><paramref name="textReader"/> or <paramref name="encoding"/> is null.</exception>
+        public virtual DbDataReader ParseReader(TextReader textReader, Encoding encoding)
         {
             if (textReader == null)
             {
@@ -134,7 +170,7 @@ namespace DelimitedDataParser
 
             if (encoding == null)
             {
-                encoding = Encoding.Default;
+                throw new ArgumentNullException(nameof(encoding));
             }
 
             return new DelimitedDataReader(

--- a/test/DelimitedDataParser.Test/ExporterTest.Reader.cs
+++ b/test/DelimitedDataParser.Test/ExporterTest.Reader.cs
@@ -603,7 +603,7 @@ namespace DelimitedDataParser
             {
                 stringReader = new StringReader(expected.ToString());
 
-                using (var dataReader = new DelimitedDataReader(stringReader, ',', true))
+                using (var dataReader = new DelimitedDataReader(stringReader, Encoding.UTF8, ',', true))
                 {
                     var sut = new Exporter();
 

--- a/test/DelimitedDataParser.Test/ParserTest.Reader.cs
+++ b/test/DelimitedDataParser.Test/ParserTest.Reader.cs
@@ -17,6 +17,14 @@ namespace DelimitedDataParser
         }
 
         [Fact]
+        public void ParseReader_Without_Valid_Encoding()
+        {
+            var parser = new Parser();
+
+            Assert.Throws<ArgumentNullException>(() => parser.ParseReader(GetTextReader(string.Empty), null));
+        }
+
+        [Fact]
         public void ParseReader_Can_Parse_Empty_Stream()
         {
             var parser = new Parser();

--- a/test/DelimitedDataParser.Test/ParserTest.Reader.cs
+++ b/test/DelimitedDataParser.Test/ParserTest.Reader.cs
@@ -1500,49 +1500,6 @@ namespace DelimitedDataParser
         }
 
         [Theory]
-        [InlineData(1, -1)]
-        [InlineData(1, 1)]
-        [InlineData(1, 2)]
-        [InlineData(2, 2)]
-        public void ParseReader_GetBytes_BufferOffsetOutOfRange_Throws(int bufferLength, int bufferOffset)
-        {
-            var input = "Data 1";
-
-            var parser = new Parser
-            {
-                UseFirstRowAsColumnHeaders = false
-            };
-
-            var reader = parser.ParseReader(GetTextReader(input));
-            reader.Read();
-
-            var buffer = new byte[bufferLength];
-            Assert.Throws<ArgumentOutOfRangeException>(() => reader.GetBytes(0, 0, buffer, bufferOffset, 1));
-        }
-
-        [Theory]
-        [InlineData(0, 1)]
-        [InlineData(0, 2)]
-        [InlineData(1, 2)]
-        [InlineData(2, 3)]
-        [InlineData(2, 4)]
-        public void ParseReader_GetBytes_BufferNotLongEnough_Throws(int bufferLength, int length)
-        {
-            var input = "Data 1";
-
-            var parser = new Parser
-            {
-                UseFirstRowAsColumnHeaders = false
-            };
-
-            var reader = parser.ParseReader(GetTextReader(input));
-            reader.Read();
-
-            var buffer = new byte[bufferLength];
-            Assert.Throws<ArgumentException>(() => reader.GetBytes(0, 0, buffer, 0, length));
-        }
-
-        [Theory]
         [InlineData("Data 1", 6, 6)]
         [InlineData("Foo", 3, 3)]
         public void ParseReader_GetBytes_ReturnsExpectedCountWithNullBuffer(string input, int length, int expected)
@@ -1800,6 +1757,32 @@ namespace DelimitedDataParser
 
             Assert.Equal(outputBytes.Length, readerLength);
             Assert.Equal<byte>(outputBytes, readerOutput);
+        }
+
+        [Theory]
+        [InlineData(1, "123")]
+        [InlineData(1, "xy")]
+        [InlineData(3, "xy1234,z")]
+        public void ParseReader_GetBytes_ReadsUpToBufferLength(int bufferLength, string inputText)
+        {
+            var parser = new Parser();
+            var buffer = new byte[bufferLength];
+            var bytesRead = 0L;
+
+            using (var sr = new StringReader(inputText))
+            {
+                using (var reader = parser.ParseReader(sr))
+                {
+                    bytesRead = reader.GetBytes(
+                        0,
+                        0,
+                        buffer,
+                        0,
+                        inputText.Length);
+                }
+            }
+
+            Assert.Equal(bufferLength, bytesRead);
         }
     }
 }

--- a/test/DelimitedDataParser.Test/ParserTest.cs
+++ b/test/DelimitedDataParser.Test/ParserTest.cs
@@ -35,6 +35,14 @@ namespace DelimitedDataParser
         }
 
         [Fact]
+        public void Fails_Without_Valid_Encoding()
+        {
+            var parser = new Parser();
+
+            Assert.Throws<ArgumentNullException>(() => parser.Parse(GetTextReader(string.Empty), null));
+        }
+
+        [Fact]
         public void Can_Parse_Column_Names_From_First_Row()
         {
             string input = @"Field 1,Field 2,Field 3";

--- a/test/DelimitedDataParser.Test/ParserTest.cs
+++ b/test/DelimitedDataParser.Test/ParserTest.cs
@@ -267,7 +267,7 @@ namespace DelimitedDataParser
             return new StringReader(input);
         }
 
-        private static TextReader GetTextReader(string input, Encoding encoding)
+        private static StreamReader GetTextReader(string input, Encoding encoding)
         {
             if (encoding == null)
             {


### PR DESCRIPTION
Add an encoding to ensure the correct bytes are returned by `GetBytes()` by  and align `GetBytes()` behaviour with .NET framework implementations of `IDataReader`.

When returning the bytes representing text data we need to use an encoding to determine the correct byte representation. Casting directly from `char` to `byte` causes incorrect values for multi-bytes characters. Some behaviours of `GetBytes()`, such as reading data from an offset, have been update to match framework behaviour.

An encoding is now specified by:
- Passing a `StreamReader` to a new overload of `ParseReader()`. In this case the encoding on the `StreamReader` is used.
- Passing an explicit encoding along with a `TextReader` to `ParseReader()`.

Fixes #11