### PR TITLE
Trim column headers by default, and bump major version

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ while (reader.Read())
 
 * `FieldSeparator` - the character used as field delimiter in the text file. Default: `,` (i.e., CSV).
 * `UseFirstRowAsColumnHeaders` - specifies whether the first row of the text file should be treated as a header row. Default: `true`.
+* `TrimColumnHeaders` - specifies whether the column headers, if present, should have whitespace trimmed before being used as a key.
 
 ## Exporter
 

--- a/src/DelimitedDataParser/DelimitedDataParser.csproj
+++ b/src/DelimitedDataParser/DelimitedDataParser.csproj
@@ -6,7 +6,7 @@
         <CodeAnalysisRuleSet>..\..\CustomExtendedCorrectnessRules.ruleset</CodeAnalysisRuleSet>
         <Authors>Enable · enable.com</Authors>
         <Company>Enable</Company>
-        <Version>4.2.1</Version>
+        <Version>5.0.0</Version>
         <Description>C# library for parsing and exporting tabular data in delimited format (e.g. CSV).</Description>
         <Copyright>Copyright © 2018</Copyright>
         <PackageIconUrl>https://github.com/EnableSoftware.png</PackageIconUrl>

--- a/src/DelimitedDataParser/DelimitedDataReader.cs
+++ b/src/DelimitedDataParser/DelimitedDataReader.cs
@@ -607,7 +607,7 @@ namespace DelimitedDataParser
             // Here we assume that the current row is the header row.
             if (_trimColumnHeaders)
             {
-                _fieldNameLookup = _currentRow.Select(o => o == null ? o : o.Trim()).ToList().AsReadOnly();
+                _fieldNameLookup = _currentRow.Select(o => o?.Trim()).ToList().AsReadOnly();
             }
             else
             {

--- a/src/DelimitedDataParser/DelimitedDataReader.cs
+++ b/src/DelimitedDataParser/DelimitedDataReader.cs
@@ -5,6 +5,7 @@ using System.Data;
 using System.Data.Common;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading;
 
@@ -20,6 +21,7 @@ namespace DelimitedDataParser
         private readonly Encoding _encoding;
         private readonly char _fieldSeparator;
         private readonly bool _useFirstRowAsColumnHeaders;
+        private readonly bool _trimColumnHeaders;
         private readonly CancellationToken _cancellationToken;
         private readonly char[] _buffer = new char[4096];
 
@@ -37,12 +39,14 @@ namespace DelimitedDataParser
             Encoding encoding,
             char fieldSeparator,
             bool useFirstRowAsColumnHeaders,
+            bool trimColumnHeaders,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             _textReader = textReader ?? throw new ArgumentNullException(nameof(textReader));
             _encoding = encoding ?? throw new ArgumentException(nameof(encoding));
             _fieldSeparator = fieldSeparator;
             _useFirstRowAsColumnHeaders = useFirstRowAsColumnHeaders;
+            _trimColumnHeaders = trimColumnHeaders;
             _cancellationToken = cancellationToken;
         }
 
@@ -601,7 +605,14 @@ namespace DelimitedDataParser
         private void GenerateFieldLookup()
         {
             // Here we assume that the current row is the header row.
-            _fieldNameLookup = new List<string>(_currentRow).AsReadOnly();
+            if (_trimColumnHeaders)
+            {
+                _fieldNameLookup = _currentRow.Select(o => o == null ? o : o.Trim()).ToList().AsReadOnly();
+            }
+            else
+            {
+                _fieldNameLookup = new List<string>(_currentRow).AsReadOnly();
+            }
         }
 
         private void GenerateDefaultFieldNameLookup()

--- a/src/DelimitedDataParser/Parser.cs
+++ b/src/DelimitedDataParser/Parser.cs
@@ -22,6 +22,7 @@ namespace DelimitedDataParser
         private ISet<string> _columnNamesAsText;
         private char _fieldSeparator = ',';
         private bool _useFirstRowAsColumnHeaders = true;
+        private bool _trimColumnHeaders = true;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Parser"/> class.
@@ -61,6 +62,23 @@ namespace DelimitedDataParser
             set
             {
                 _useFirstRowAsColumnHeaders = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the column headers, if present, should have whitespace trimmed.
+        /// The default value is <c>true</c>.
+        /// </summary>
+        public virtual bool TrimcolumnHeaders
+        {
+            get
+            {
+                return _trimColumnHeaders;
+            }
+
+            set
+            {
+                _trimColumnHeaders = value;
             }
         }
 
@@ -183,6 +201,7 @@ namespace DelimitedDataParser
                 encoding,
                 _fieldSeparator,
                 _useFirstRowAsColumnHeaders,
+                _trimColumnHeaders,
                 cancellationToken);
         }
 
@@ -207,6 +226,7 @@ namespace DelimitedDataParser
                 streamReader.CurrentEncoding,
                 _fieldSeparator,
                 _useFirstRowAsColumnHeaders,
+                _trimColumnHeaders,
                 cancellationToken);
         }
 

--- a/src/DelimitedDataParser/Parser.cs
+++ b/src/DelimitedDataParser/Parser.cs
@@ -66,10 +66,10 @@ namespace DelimitedDataParser
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the column headers, if present, should have whitespace trimmed.
+        /// Gets or sets a value indicating whether the column headers, if present, should have whitespace trimmed before being used as a key
         /// The default value is <c>true</c>.
         /// </summary>
-        public virtual bool TrimcolumnHeaders
+        public virtual bool TrimColumnHeaders
         {
             get
             {

--- a/test/DelimitedDataParser.Test/ExporterTest.Reader.cs
+++ b/test/DelimitedDataParser.Test/ExporterTest.Reader.cs
@@ -603,7 +603,7 @@ namespace DelimitedDataParser
             {
                 stringReader = new StringReader(expected.ToString());
 
-                using (var dataReader = new DelimitedDataReader(stringReader, Encoding.UTF8, ',', true))
+                using (var dataReader = new DelimitedDataReader(stringReader, Encoding.UTF8, ',', true, false))
                 {
                     stringReader = null;
 

--- a/test/DelimitedDataParser.Test/ParserTest.cs
+++ b/test/DelimitedDataParser.Test/ParserTest.cs
@@ -76,7 +76,7 @@ namespace DelimitedDataParser
             string input = @"Field 1 , Field 2, Field 3 ";
 
             var parser = new Parser();
-            parser.TrimcolumnHeaders = false;
+            parser.TrimColumnHeaders = false;
 
             var output = parser.Parse(GetTextReader(input));
 

--- a/test/DelimitedDataParser.Test/ParserTest.cs
+++ b/test/DelimitedDataParser.Test/ParserTest.cs
@@ -57,6 +57,36 @@ namespace DelimitedDataParser
         }
 
         [Fact]
+        public void Will_Trim_Column_Names_By_Default()
+        {
+            string input = @"Field 1 , Field 2, Field 3 ";
+
+            var parser = new Parser();
+            var output = parser.Parse(GetTextReader(input));
+
+            Assert.Equal(3, output.Columns.Count);
+            Assert.Equal("Field 1", output.Columns[0].ColumnName);
+            Assert.Equal("Field 2", output.Columns[1].ColumnName);
+            Assert.Equal("Field 3", output.Columns[2].ColumnName);
+        }
+
+        [Fact]
+        public void Will_Not_Trim_Column_Names_If_Prevented()
+        {
+            string input = @"Field 1 , Field 2, Field 3 ";
+
+            var parser = new Parser();
+            parser.TrimcolumnHeaders = false;
+
+            var output = parser.Parse(GetTextReader(input));
+
+            Assert.Equal(3, output.Columns.Count);
+            Assert.Equal("Field 1 ", output.Columns[0].ColumnName);
+            Assert.Equal(" Field 2", output.Columns[1].ColumnName);
+            Assert.Equal(" Field 3 ", output.Columns[2].ColumnName);
+        }
+
+        [Fact]
         public void Can_Parse_Empty_Column_Names()
         {
             string input = @",";


### PR DESCRIPTION
Add the option to trim column headers when reading from the input text, and make it the default. This is a potentially breaking change, so increment the major version as well. 