### PR TITLE
Sanitize strings even when escape characters are used, and bump major…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Initial public release.
 
 [unreleased]: https://github.com/EnableSoftware/DelimitedDataParser/compare/v4.2.0...HEAD
+[6.0.0]: https://github.com/EnableSoftware/DelimitedDataParser/compare/v5.0.0...v6.0.0
+[5.0.0]: https://github.com/EnableSoftware/DelimitedDataParser/compare/v4.2.1...v5.0.0
 [4.2.1]: https://github.com/EnableSoftware/DelimitedDataParser/compare/v4.2.0...v4.2.1
 [4.2.0]: https://github.com/EnableSoftware/DelimitedDataParser/compare/v4.1.0...v4.2.0
 [4.1.0]: https://github.com/EnableSoftware/DelimitedDataParser/compare/v4.0.3...v4.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+## [6.0.0] - 2021-12-13
+
+### Added
+
+- Update _sanitizeStrings default to `true`.
+- Sanitize strings will now also take effect when escape characters are used.
+
+## [5.0.0] - 2021-11-23
+
+### Added
+
+- Add the option to trim column headers when reading from the input text, and make it the default.
+
 ## [4.2.1] - 2020-11-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ using (var fileWriter = File.CreateText("my.csv"))
 ### Configuration properties
 
 * `FieldSeparator` - the character used as field delimiter in the text file. Default: `,` (i.e., CSV).
-* `SanitizeStrings` - specifies whether strings should be sanitized, prepending blacklisted characters at the start of the string with a single quote `'`. The default value is `false`.
+* `SanitizeStrings` - specifies whether strings should be sanitized, prepending blacklisted characters at the start of the string with a single quote `'`. Default: `true`.
 * `IncludeEscapeCharacters` - specifies whether each value should be escaped by wrapping in quotation marks. Default: `true`.
 * `OutputColumnHeaders` - specifies whether an initial row containing column names should be written to the output. Default: `true`.
 * `UseExtendedPropertyForColumnName(string key)` - specifies a key that is used to search on the ExtendedProperties of a DataColumn. If it finds a value this will be used as the column header, if no match is found it will default to the column's ColumnName. This should be used if you are required to output a different column header to what is stored on the column's ColumnName.

--- a/src/DelimitedDataParser/DelimitedDataParser.csproj
+++ b/src/DelimitedDataParser/DelimitedDataParser.csproj
@@ -6,7 +6,7 @@
         <CodeAnalysisRuleSet>..\..\CustomExtendedCorrectnessRules.ruleset</CodeAnalysisRuleSet>
         <Authors>Enable · enable.com</Authors>
         <Company>Enable</Company>
-        <Version>5.0.0</Version>
+        <Version>6.0.0</Version>
         <Description>C# library for parsing and exporting tabular data in delimited format (e.g. CSV).</Description>
         <Copyright>Copyright © 2018</Copyright>
         <PackageIconUrl>https://github.com/EnableSoftware.png</PackageIconUrl>

--- a/src/DelimitedDataParser/Exporter.cs
+++ b/src/DelimitedDataParser/Exporter.cs
@@ -19,7 +19,7 @@ namespace DelimitedDataParser
         public static readonly char TabSeparator = '\t';
 
         private static readonly string[] UnsafeLeadingCharacters = { "=", "+", "-", "@" };
-        
+
         private readonly IProgress<int> _progress;
 
         private ISet<string> _columnNamesAsText;
@@ -27,7 +27,7 @@ namespace DelimitedDataParser
 
         private char _fieldSeparator = ',';
         private bool _includeEscapeCharacters = true;
-        private bool _sanitizeStrings;
+        private bool _sanitizeStrings = true;
         private bool _outputColumnHeaders = true;
         private bool _useExtendedPropertyForColumnName;
         private string _extendedPropertyKey;
@@ -307,6 +307,11 @@ namespace DelimitedDataParser
         /// <returns>The escaped string</returns>
         private string CsvEscape(string value, bool valueAsText)
         {
+            if (_sanitizeStrings)
+            {
+                value = Sanitize(value);
+            }
+
             if (_includeEscapeCharacters)
             {
                 value = value.Replace(@"""", @"""""");
@@ -319,11 +324,6 @@ namespace DelimitedDataParser
                 {
                     value = string.Concat(@"""", value, @"""");
                 }
-            }
-
-            if (_sanitizeStrings)
-            {
-                value = Sanitize(value);
             }
 
             return value;

--- a/test/DelimitedDataParser.Test/ExporterTest.Reader.cs
+++ b/test/DelimitedDataParser.Test/ExporterTest.Reader.cs
@@ -608,6 +608,7 @@ namespace DelimitedDataParser
                     stringReader = null;
 
                     var sut = new Exporter();
+                    sut.SanitizeStrings = false;
 
                     stopwatch = Stopwatch.StartNew();
                     output = sut.ExportToString(dataReader);

--- a/test/DelimitedDataParser.Test/ExporterTest.cs
+++ b/test/DelimitedDataParser.Test/ExporterTest.cs
@@ -424,6 +424,7 @@ namespace DelimitedDataParser
             }
 
             var exporter = new Exporter();
+            exporter.SanitizeStrings = false;
 
             var stopwatch = System.Diagnostics.Stopwatch.StartNew();
 


### PR DESCRIPTION
… version

- The default for _sanitizeStrings has been changed from false to `True`. This constitutes a change in functionality, and hence a major version bump.
- Strings are now sanitized even when _includeEscapeCharacters is set to `True`